### PR TITLE
Do not install pre-compiled packages with wheel

### DIFF
--- a/sklearn_user_data.sh
+++ b/sklearn_user_data.sh
@@ -22,7 +22,7 @@ make_swap () {
 do_pip () {
     pip install --upgrade pip wheel
     IFS=' ' ; for pkg in numpy scipy scikit-learn; do
-        pip install --use-wheel $pkg
+        pip install --no-binary :all: $pkg
     done
 }
 


### PR DESCRIPTION
It seems the pre-compiled libraries installed with wheel can not be properly stripped (#1) due to a different version of strip command. So all the packages should be built from scratch.

Reference: https://github.com/numpy/numpy/issues/7570
