### PR TITLE
Adding AWS CodeBuild wrapper

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,12 +25,18 @@ strip_virtualenv () {
     echo "venv original size $(du -sh $VIRTUAL_ENV | cut -f1)"
     find $VIRTUAL_ENV/lib64/python2.7/site-packages/ -name "*.so" | xargs strip
     echo "venv stripped size $(du -sh $VIRTUAL_ENV | cut -f1)"
-
-    pushd $VIRTUAL_ENV/lib64/python2.7/site-packages/ && zip -r -9 -q /outputs/venv.zip * ; popd
-    echo "site-packages compressed size $(du -sh /outputs/venv.zip | cut -f1)"
-
-    pushd $VIRTUAL_ENV && zip -r -q /outputs/full-venv.zip * ; popd
-    echo "venv compressed size $(du -sh /outputs/full-venv.zip | cut -f1)"
+    ls $VIRTUAL_ENV/lib64/python2.7/site-packages/
+    pwd
+    pushd $VIRTUAL_ENV/lib64/python2.7/site-packages/
+    pwd
+    zip -r -9 -q outputs/venv.zip *
+    popd
+    echo "site-packages compressed size $(du -sh $VIRTUAL_ENV/outputs/venv.zip | cut -f1)"
+    popd
+    pushd $VIRTUAL_ENV
+    zip -r -q outputs/full-venv.zip * 
+    popd
+    echo "venv compressed size $(du -sh $VIRTUAL_ENV/outputs/full-venv.zip | cut -f1)"
 }
 
 shared_libs () {

--- a/build.sh
+++ b/build.sh
@@ -29,14 +29,15 @@ strip_virtualenv () {
     pwd
     pushd $VIRTUAL_ENV/lib64/python2.7/site-packages/
     pwd
-    zip -r -9 -q outputs/venv.zip *
+    mkdir ../outputs
+    zip -r -9 -q ../outputs/venv.zip *
     popd
-    echo "site-packages compressed size $(du -sh $VIRTUAL_ENV/outputs/venv.zip | cut -f1)"
-    popd
-    pushd $VIRTUAL_ENV
-    zip -r -q outputs/full-venv.zip * 
-    popd
-    echo "venv compressed size $(du -sh $VIRTUAL_ENV/outputs/full-venv.zip | cut -f1)"
+    echo "site-packages compressed size $(du -sh $VIRTUAL_ENV/lib64/python2.7/outputs/venv.zip | cut -f1)"
+    cp  $VIRTUAL_ENV/lib64/python2.7/outputs/venv.zip .
+    #pushd $VIRTUAL_ENV
+    #zip -r -q outputs/full-venv.zip * 
+    #popd
+    #echo "venv compressed size $(du -sh $VIRTUAL_ENV/outputs/full-venv.zip | cut -f1)"
 }
 
 shared_libs () {

--- a/build.sh
+++ b/build.sh
@@ -25,19 +25,12 @@ strip_virtualenv () {
     echo "venv original size $(du -sh $VIRTUAL_ENV | cut -f1)"
     find $VIRTUAL_ENV/lib64/python2.7/site-packages/ -name "*.so" | xargs strip
     echo "venv stripped size $(du -sh $VIRTUAL_ENV | cut -f1)"
-    ls $VIRTUAL_ENV/lib64/python2.7/site-packages/
-    pwd
     pushd $VIRTUAL_ENV/lib64/python2.7/site-packages/
-    pwd
     mkdir ../outputs
     zip -r -9 -q ../outputs/venv.zip *
     popd
     echo "site-packages compressed size $(du -sh $VIRTUAL_ENV/lib64/python2.7/outputs/venv.zip | cut -f1)"
     cp  $VIRTUAL_ENV/lib64/python2.7/outputs/venv.zip .
-    #pushd $VIRTUAL_ENV
-    #zip -r -q outputs/full-venv.zip * 
-    #popd
-    #echo "venv compressed size $(du -sh $VIRTUAL_ENV/outputs/full-venv.zip | cut -f1)"
 }
 
 shared_libs () {

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,19 @@
+version: 0.1
+
+phases:
+  install:
+    commands:
+      - echo Nothing to do in the install phase...
+  pre_build:
+    commands:
+      - echo Nothing to do in the pre_build phase...
+  build:
+    commands:
+      - echo Build started on `date`
+      - bash build.sh
+  post_build:
+    commands:
+      - echo Build completed on `date`
+artifacts:
+  files:
+    - venv.zip


### PR DESCRIPTION
I like to do my builds with CodeBuild. Actually I do a lot of my runs with CodeBuild AKA "FatLambda".

TODO:
*Write a Serverless/SAM template to provision the CodeBuild, an S3 bucket to store the build artifacts, provision the lambda.

*Write some unit tests that the Codebuild job can run.

*Add a Makefile so full recompiles only happen if the low level code changes.


